### PR TITLE
[feat] 게시글 상세 조회시 댓글 작성자 확인 기능 추가

### DIFF
--- a/out/production/resources/application.properties
+++ b/out/production/resources/application.properties
@@ -1,1 +1,7 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:db;MODE=MYSQL;
+spring.datasource.username=sa
+spring.datasource.password=
 
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/java/com/example/haelogproject/post/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/haelogproject/post/dto/CommentResponseDto.java
@@ -16,11 +16,11 @@ public class CommentResponseDto {
     private boolean myComment = true;
     private LocalDateTime createAt;
 
-    public CommentResponseDto(Comment comment, boolean isMyService) {
+    public CommentResponseDto(Comment comment, boolean isMyComment) {
         this.commentId = comment.getCommentId();
         this.commentContent = comment.getContent();
         this.commentMemberNickname = comment.getMember().getNickname();
-        this.myComment = true;
+        this.myComment = isMyComment;
         this.createAt = comment.getCreatedAt();
     }
 }

--- a/src/main/java/com/example/haelogproject/post/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/haelogproject/post/dto/CommentResponseDto.java
@@ -16,7 +16,7 @@ public class CommentResponseDto {
     private boolean myComment = true;
     private LocalDateTime createAt;
 
-    public CommentResponseDto(Comment comment) {
+    public CommentResponseDto(Comment comment, boolean isMyService) {
         this.commentId = comment.getCommentId();
         this.commentContent = comment.getContent();
         this.commentMemberNickname = comment.getMember().getNickname();


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
게시글 상세 조회시 댓글을 가져오는 과정에서 요청한 맴버와 댓글의 작성자를 비교하여 댓글 작성자 여부를 확인하는 기능 추가

## 작업사항
게시글의 작성자만 확인하는 로직을 들어온 요청에서 jwt가 포함되어있다면 jwt값을 확인하여 요청한 `member` 객체를 만들고 이를 비교하여 게시글 작성자 여부, 댓글 작성자 여부 확인해주고 확인한 결과를 응답해준다.


