### PR TITLE
[fix] 게시물 상세조회 오류 수정

### DIFF
--- a/src/main/java/com/example/haelogproject/post/service/PostService.java
+++ b/src/main/java/com/example/haelogproject/post/service/PostService.java
@@ -163,21 +163,25 @@ public class PostService {
         String token = jwtUtil.resolveToken(request, "Authorization");
         boolean isLogin = (token != null) ? true : false;
 
-        // jwt 내부 값 확인
-        Claims claims = jwtUtil.getUserInfoFromToken(token);
-
-        // jwt안의 정보를 이용하여 유저 조회
-        Optional<Member> memberInJwt = memberRepository.findByLoginId(claims.getSubject());;
         Member requestMember = new Member();
-        if (memberInJwt.isPresent()) {
-            requestMember = memberInJwt.get();
+        Claims claims = null;
+
+        // jwt 내부 값 확인
+        if (isLogin) {
+            claims = jwtUtil.getUserInfoFromToken(token);
+
+            // jwt 안의 정보를 이용하여 유저 조회
+            Optional<Member> memberInJwt = memberRepository.findByLoginId(claims.getSubject());;
+            if (memberInJwt.isPresent()) {
+                requestMember = memberInJwt.get();
+            }
         }
 
+        // 요청한 맴버와 게시글의 작성자 일치 여부
         boolean isAuthor = false;
 
-
         // 로그인 상태라면 조회 요청한 유저와 게시물을 작성한 유저가 동일 유저인지 확인
-        if (isLogin == true)
+        if (isLogin)
             if (requestMember.getMemberId().equals(post.getMemberId())) {
             isAuthor = true;
         }
@@ -188,7 +192,7 @@ public class PostService {
         for (Comment comment : commentList) {
             // 요청한 사용자와 댓글 작성자가 같다면 isCommenter = true
             boolean isCommenter = false;
-            if (isLogin == true) {
+            if (isLogin) {
                 if (requestMember.getMemberId().equals(comment.getMember().getMemberId())) {
                     isCommenter = true;
                 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
로그인 상태가 아닐 경우 게시물 상세조회를 안되는 오류 확인 결과 header에 jwt가 없음에도 jwt의 데이터를 꺼내오는 메서드를 실행하여 예외가 발생

## 작업사항
`PostService`의 `writePost`안의 문제를 발생시킨 메서드를 조건문으로 감싸줘 jwt가 없는 경우에는 아예 실행되지 않도록 변경하여 header에 jwt가 없는 경우에도 조회가 가능 하도록 코드를 수정함.